### PR TITLE
Add tests for TransferBenchmark [WIP]

### DIFF
--- a/AMTLB/amtlb/__init__.py
+++ b/AMTLB/amtlb/__init__.py
@@ -1,2 +1,3 @@
 from common import *
 import transfer_benchmark
+from transfer_benchmark import TransferBenchmark, TransferBenchmarkResult

--- a/AMTLB/amtlb/common.py
+++ b/AMTLB/amtlb/common.py
@@ -84,11 +84,23 @@ class BenchmarkParms(object):
                  game_names=GAMES,
                  game_version=0,
                  ):
+        assert num_folds > 1, 'Must have more than one fold'
         self.num_folds = num_folds
+
+        assert max_rounds_w_no_reward > 1, \
+            'Max rounds with no reward must be greater than 1'
         self.max_rounds_w_no_reward = max_rounds_w_no_reward
+
+        assert seed is None or isinstance(seed, int)
         self.seed = random.randint(0, 2**64-1) if seed is None else seed
+
+        assert max_rounds_per_game > 1, 'Must have at least one round per game'
         self.max_rounds_per_game = max_rounds_per_game
+
+        assert 0 <= game_version <= 3, 'Invalid game version'
         self.game_version = game_version
+
+        assert len(game_names) > num_folds, 'Must have more games than folds'
         self.games = {game: to_identifier(game, game_version)
                       for game in game_names}
 

--- a/AMTLB/amtlb/transfer_benchmark.py
+++ b/AMTLB/amtlb/transfer_benchmark.py
@@ -19,7 +19,7 @@ def fold_name(num):
     return name
 
 
-class BenchmarkResult(object):
+class TransferBenchmarkResult(object):
     def __init__(self, agent, game=None):
         self.agent = agent
         self.rewards = []  # list of int rewards, index is round #
@@ -50,12 +50,12 @@ class EnvMaker(object):
         return env
 
 
-class TestRun(EnvMaker):
+class TransferTestRun(EnvMaker):
     def __init__(self, agent, game_name, parms):
         self.agent = agent
         self.parms = parms
         self.game = self.create_env(game_name)
-        self.result = BenchmarkResult(agent, game_name)
+        self.result = TransferBenchmarkResult(agent, game_name)
 
     def __call__(self):
         '''Test an agent on the given game'''
@@ -162,10 +162,10 @@ class TransferBenchmark(object):
                 self.game_agents[game_name] = game_agent
 
     def test(self, game_agent, game_name):
-        return TestRun(game_agent, game_name, self.parms)()
+        return TransferTestRun(game_agent, game_name, self.parms)()
 
     def train(self, fold_agent, training_set):
-        return TrainingRun(fold_agent, training_set, self.parms)()
+        return TransferTrainingRun(fold_agent, training_set, self.parms)()
 
 
     def do_folds(self):
@@ -192,7 +192,7 @@ class TransferBenchmark(object):
                     self.tested_agent_filename(fold_num, game_name))
 
 
-class TrainingRun(EnvMaker):
+class TransferTrainingRun(EnvMaker):
     def __init__(self, agent, training_set, parms):
         self.agent = agent
         self.training_set = training_set
@@ -200,7 +200,7 @@ class TrainingRun(EnvMaker):
         self.envs = defaultdict(self.create_env)
         self.game_rounds_left = {game: self.max_test_game_rounds
                                  for game in training_set}
-        self.trace_result = BenchmarkResult(agent)
+        self.trace_result = TransferBenchmarkResult(agent)
 
     def total_rounds_left(self):
         return sum(self.game_rounds_left.values())
@@ -221,9 +221,6 @@ class TrainingRun(EnvMaker):
             if cumulative_sum >= threshold:
                 break
         return game, self.envs[game]  # Will lazily initialize env
-
-    def keep_playing(self, game_name, done, no_reward_turns):
-        return
 
     def __call__(self):
         round = 0

--- a/AMTLB/amtlb/transfer_benchmark.py
+++ b/AMTLB/amtlb/transfer_benchmark.py
@@ -222,9 +222,6 @@ class TrainingRun(EnvMaker):
                 break
         return game, self.envs[game]  # Will lazily initialize env
 
-    def keep_playing(self, game_name, done, no_reward_turns):
-        return
-
     def __call__(self):
         round = 0
         while self.total_rounds_left() > 0:

--- a/AMTLB/runtests
+++ b/AMTLB/runtests
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python -m pytest tests/
+python -m pytest tests/ $1 $2 $3

--- a/AMTLB/tests/conftest.py
+++ b/AMTLB/tests/conftest.py
@@ -1,0 +1,92 @@
+from random import randint, sample
+from functools import partial
+import os.path
+from string import lowercase
+
+import pytest
+import mock
+
+import amtlb
+
+
+@pytest.fixture
+def game_names():
+    prospects = [
+        'air_raid', 'alien', 'amidar', 'assault', 'asterix',
+        'asteroids', 'atlantis', 'bank_heist', 'battle_zone',
+        'beam_rider', 'berzerk', 'bowling', 'boxing', 'breakout',
+        'carnival', 'centipede', 'chopper_command', 'crazy_climber',
+        'demon_attack', 'double_dunk', 'elevator_action', 'enduro',
+        'fishing_derby', 'freeway', 'frostbite', 'gopher', 'gravitar',
+        'ice_hockey', 'jamesbond', 'journey_escape', 'kangaroo', 'krull',
+        'kung_fu_master', 'montezuma_revenge', 'ms_pacman',
+        'name_this_game', 'phoenix', 'pitfall', 'pong', 'pooyan',
+        'private_eye', 'qbert', 'riverraid', 'road_runner', 'robotank',
+        'seaquest', 'skiing', 'solaris', 'space_invaders', 'star_gunner',
+        'tennis', 'time_pilot', 'tutankham', 'up_n_down', 'venture',
+        'video_pinball', 'wizard_of_wor', 'yars_revenge', 'zaxxon'
+    ]
+    return sample(prospects, randint(13, len(prospects)))
+
+
+@pytest.fixture
+def num_games(game_names):
+    return len(game_names)
+
+
+@pytest.fixture(params=[3, 5, 7, 11, 13])
+def num_folds(request):
+    return request.param
+
+@pytest.fixture
+def benchmark_parms(game_names, num_folds):
+    return partial(
+        amtlb.BenchmarkParms,
+        game_names=game_names,
+        num_folds=num_folds,
+    )
+
+@pytest.fixture
+def bp(benchmark_parms):
+    return benchmark_parms()
+
+
+@pytest.fixture
+def random_benchmark_parms(game_names):
+    return partial(
+        amtlb.BenchmarkParms,
+        num_folds=randint(2, 11),
+        max_rounds_w_no_reward=randint(0, 1000),
+        seed=randint(0, 10000),
+        game_names=game_names,
+        game_version=randint(0, 3),
+    )
+
+@pytest.fixture
+def random_filename(tmpdir):
+    return os.path.join(str(tmpdir), ''.join(sample(lowercase, 10)))
+
+
+@pytest.fixture
+def MockAgent():
+    return mock.Mock(spec=amtlb.Agent)
+
+
+@pytest.fixture
+def transfer_benchmark(MockAgent, bp):
+    return partial(
+        amtlb.TransferBenchmark,
+        parms=bp,
+        AgentClass=MockAgent,
+    )
+
+
+@pytest.fixture
+def tb(transfer_benchmark):
+    return transfer_benchmark()
+
+
+def folds_equal(A, B):
+    _A = {frozenset(a) for a in A}
+    _B = {frozenset(b) for b in B}
+    return _A == _B

--- a/AMTLB/tests/test_common.py
+++ b/AMTLB/tests/test_common.py
@@ -6,45 +6,10 @@ import os.path
 
 import pytest
 from mock import MagicMock, patch
-
 import amtlb
 
+from conftest import folds_equal
 
-@pytest.fixture
-def game_names():
-    return list(sample(uppercase, randint(14, 26)))
-
-@pytest.fixture(params=[1, 3, 5, 7, 11, 13])
-def num_folds(request):
-    return request.param
-
-@pytest.fixture
-def benchmark_parms(game_names, num_folds):
-    return partial(
-        amtlb.BenchmarkParms,
-        game_names=game_names,
-        num_folds=num_folds,
-    )
-
-@pytest.fixture
-def random_benchmark_parms(game_names):
-    return partial(amtlb.BenchmarkParms,
-        num_folds=randint(0, 11),
-        max_rounds_w_no_reward=randint(0, 1000),
-        seed=randint(0, 10000),
-        game_names=game_names,
-        game_version=randint(0, 3),
-    )
-
-@pytest.fixture
-def random_filename(tmpdir):
-    return os.path.join(str(tmpdir), ''.join(sample(lowercase, 10)))
-
-
-def folds_equal(A, B):
-    _A = {frozenset(a) for a in A}
-    _B = {frozenset(b) for b in B}
-    return _A == _B
 
 class TestBenchmarkParms(object):
 
@@ -106,9 +71,10 @@ class TestBenchmarkParms(object):
         assert bp.max_rounds_w_no_reward == bp2.max_rounds_w_no_reward
         assert bp.seed == bp2.seed
         assert bp.max_rounds_per_game == bp2.max_rounds_per_game
-        assert bp.game_names == bp2.game_names
-        assert bp.game_identifiers == bp2.game_identifiers
+        assert sorted(bp.game_names) == sorted(bp2.game_names)
+        assert sorted(bp.game_identifiers) == sorted(bp2.game_identifiers)
         assert folds_equal(bp.folds, bp2.folds)
+
 
 def test_to_identifier():
     expected = 'FooGameBar-v3'

--- a/AMTLB/tests/test_transfer.py
+++ b/AMTLB/tests/test_transfer.py
@@ -1,4 +1,68 @@
-import amtlb
+from functools import partial
+
+import pytest
+import mock
+
+import amtlb.common
+import amtlb.transfer_benchmark as mut  # module under test
+
+from conftest import folds_equal
+
+class TestTransferBenchmark(object):
+    def test_test_set_returns_correct_fold(self, tb, bp, num_folds):
+        '''Returns the correct fold for a given index'''
+        for i in range(0, num_folds):
+            obtained = tb.test_set(i)
+            expected = bp.folds[i]
+            assert folds_equal(tb.test_set(i), bp.folds[i])
+
+    def test_test_set_returns_no_entries_from_training_set(self, tb, num_folds):
+        '''Returns no entries from the training set.
+
+        A sanity check about the relationship between test_set and
+        training_set
+        '''
+        empty_set = set()
+        for i in range(0, num_folds):
+            test_set = tb.test_set(i)
+            training_set = tb.training_set(i)
+            assert test_set.intersection(training_set) == empty_set
+
+    def test_training_set_returns_all_but_test_set(self, tb, bp, num_folds):
+        '''Returns all but test set.
+
+        Sanity check that test games + training_games == all games
+        '''
+        all_games = set(bp.game_identifiers)
+        for i in range(0, num_folds):
+            test_games = tb.test_set(i)
+            training_games = tb.training_set(i)
+            assert test_games.union(training_games) == all_games
+
+    def test_do_folds_all_fold_agents_get_trained(self):
+        '''All fold_agents need to be trained'''
+        pass
+ # .do_folds - high priority
+  # all fold_agents get trained
+  # fold agents are saved after training
+  # a fold agent gets tested on each test game
+  # a fold agent results on a game are saved
+  # the "tested_agent' is saved
+ # .ensure_game_agents - medium priority
+  # if there's no agent for a game it makes one
+  # if there is an agent, it does nothing
+ # .default_dir  - low priority
+  # check that it returns something matching a regex
+ # .game_agent_filename  - low priority
+  # check with a regex
+ # .fold_agent_filename  - low priority
+  # check with a regex
+ # .tested_agent_filename - low priority
+  # check with a regex
+ # .test - low priority
+  # returns a TestRun
+ # .train  - low priority
+  # returns a TrainingRun
 
 
 # TestRun
@@ -8,19 +72,16 @@ import amtlb
  # records every reward
  # gives action from the agent to the game.step method
 
-# TransferBenchmark
- # .test_set
-  # returns the correct fold
-  # returns no entries from the training set
- # .training_set
-  # returns all entries except from the test set
- # .default_dir
-  # check that it returns something matching a regex
- # .game_agent_filename
-  # check with a regex
- # .fold_agent_filename
-  # check with a regex
- # .tested_agent_filename
-  # check with a regex
- # .ensure_game_agents
-  #
+
+# TrainingRun
+ # max_rounds_w_no_reward is respected
+ # max_rounds_per_game is respected
+ # .total_rounds_left - low priority
+   # Ensure it sums up the right property from self.game_rounds_left
+ # .sample_env - High priority
+   # create a fake distribution
+     # [0 3 0], ensure index 1 is selected
+     # [2,0, 0], ensure index 0 is selected
+     # [0, 0, 3], ensure index 3 is selected
+     # [1, 2, 0], ensure runs are proportional
+   # ensure returns game name and an environment for the game

--- a/AMTLB/tests/test_transfer.py
+++ b/AMTLB/tests/test_transfer.py
@@ -1,4 +1,7 @@
+import pytest
+
 import amtlb
+import amtlb.common
 
 
 # TestRun
@@ -8,19 +11,55 @@ import amtlb
  # records every reward
  # gives action from the agent to the game.step method
 
-# TransferBenchmark
- # .test_set
+@pytest.fixture
+def agent():
+    return mock.Mock(spec=amtlb.Agent)
+
+@pytest.fixture
+def transfer_benchmark(agent):
+    return TransferBenchmark
+
+@pytest.fixture
+def parms():
+    return mock.Mock(spec=amtlb.BenchmarkParms)()
+
+class TransferBenchmark(object):
+    def test_test_set_returns_correct_fold(mock_transfer_benchmark):
+
+ # .test_set - high priority
   # returns the correct fold
   # returns no entries from the training set
- # .training_set
+ # .training_set - high priority
   # returns all entries except from the test set
- # .default_dir
+ # .default_dir  - low priority
   # check that it returns something matching a regex
- # .game_agent_filename
+ # .game_agent_filename  - low priority
   # check with a regex
- # .fold_agent_filename
+ # .fold_agent_filename  - low priority
   # check with a regex
- # .tested_agent_filename
+ # .tested_agent_filename - low priority
   # check with a regex
- # .ensure_game_agents
-  #
+ # .ensure_game_agents - medium priority
+  # if there's no agent for a game it makes one
+  # if there is an agent, it does nothing
+ # .test - low priority
+  # returns a TestRun
+ # .train  - low priority
+  # returns a TrainingRun
+ # .do_folds - high priority
+  # all fold_agents get trained
+  # fold agents are saved after training
+  # a fold agent gets tested on each test game
+  # a fold agent results on a game are saved
+  # the "tested_agent' is saved
+
+# TrainingRun
+ # .total_rounds_left - low priority
+   # Ensure it sums up the right property from self.game_rounds_left
+ # .sample_env - High priority
+   # create a fake distribution
+     # [0 3 0], ensure index 1 is selected
+     # [2,0, 0], ensure index 0 is selected
+     # [0, 0, 3], ensure index 3 is selected
+     # [1, 2, 0], ensure runs are proportional
+   # ensure returns game name and an environment for the game


### PR DESCRIPTION
Should resolve #4 when completed. Just need some basic checks for functionality

- `.test_set` - high priority
     - [ ] returns the correct fold
     - [ ] returns no entries from the training set
- `.training_set` - high priority
     - [ ] returns all entries except from the test set
- `.default_dir`  - low priority
     - [ ] check that it returns something matching a regex
- `.game_agent_filename`  - low priority
     - [ ] check with a regex
- `.fold_agent_filename`  - low priority
     - [ ] check with a regex
- `.tested_agent_filename` - low priority
     - [ ] check with a regex
- `.ensure_game_agents` - medium priority
     - [ ] if there's no agent for a game it makes one
     - [ ] if there is an agent, it does nothing
- `.test` - low priority
     - [ ] creates a TestRun
- `.train`  - low priority
     - [ ] creates a TrainingRun
- `.do_folds` - high priority
     - [ ] all fold_agents get trained
     - [ ] fold agents are saved after training
     - [ ] a fold agent gets tested on each test game
     - [ ] a fold agent results on a game are saved
     - [ ] the "tested_agent' is saved
